### PR TITLE
Guard against non-iterable map types

### DIFF
--- a/collectors/map.go
+++ b/collectors/map.go
@@ -120,7 +120,7 @@ func (mc *MapCollector) collectForMap(mapID ebpf.MapID, ch chan<- prometheus.Met
 		strconv.FormatUint(uint64(mapID), 10),
 	)
 
-	if mc.currEntriesDesc != nil {
+	if mc.currEntriesDesc != nil && mapTypeIsIterable(m.Type()) {
 		var count uint64
 		throwawayKey := discardEncoding{}
 		throwawayValues := make(sliceDiscardEncoding, 0)
@@ -138,6 +138,10 @@ func (mc *MapCollector) collectForMap(mapID ebpf.MapID, ch chan<- prometheus.Met
 			)
 		}
 	}
+}
+
+func mapTypeIsIterable(typ ebpf.MapType) bool {
+	return typ != ebpf.PerfEventArray
 }
 
 // Assert that discardEncoding implements the correct interfaces for map iterators.


### PR DESCRIPTION
If `map-count-entries` is enabled, we try to iterate over all maps. This causes issues for certain map types e.g. You will see this log `ERROR error iterating over map map_id=191 err="look up next key: lookup: not supported"` every time for a `PerfEventArray`

I've just programmed this in such a way that this problematic map type is bypassed under the hood, and in a way that can easily be extended for other types in the future, but am open to other suggestions as well (such as something more explicit in config)